### PR TITLE
TECH-1821: Bump TikTok Business SDK to v1.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### ✨ Features
+
+- **Added automatic event tracking controls** through `initializeSdk()` options for disabling all automatic events or specific install, launch, retention, and payment automatic events.
+
 ## [1.6.1] - 2026-04-25
 
 ### 🚀 Major Updates

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.6.1] - 2026-04-25
+
+### 🚀 Major Updates
+
+- **Updated to TikTok Business SDK v1.6.1** (iOS and Android)
+
+### 📱 Platform Updates
+
+- **iOS**: Updated to TikTokBusinessSDK v1.6.1 via CocoaPods
+- **Android**: Updated to tiktok-business-android-sdk v1.6.1 via Gradle
+
 ## [1.6.0] - 2025-12-18
 
 ### 🚀 Major Updates
@@ -53,12 +64,12 @@ Event names now use camelCase format to match the official TikTok Business SDK:
 
 ```js
 // Before (v1.4.1 and earlier)
-TikTokEventName.START_TRIAL = 'START_TRIAL'
-TikTokEventName.ADD_PAYMENT_INFO = 'ADD_PAYMENT_INFO'
+TikTokEventName.START_TRIAL = 'START_TRIAL';
+TikTokEventName.ADD_PAYMENT_INFO = 'ADD_PAYMENT_INFO';
 
 // After (v1.5.0)
-TikTokEventName.START_TRIAL = 'StartTrial'
-TikTokEventName.ADD_PAYMENT_INFO = 'AddPaymentInfo'
+TikTokEventName.START_TRIAL = 'StartTrial';
+TikTokEventName.ADD_PAYMENT_INFO = 'AddPaymentInfo';
 ```
 
 **Migration**: No code changes needed if using the enum constants. Only affects you if using hardcoded string values.
@@ -114,20 +125,22 @@ TikTokEventName.ADD_PAYMENT_INFO = 'AddPaymentInfo'
 
 ### ⚠️ Breaking Changes
 
-1. **Access Token Required**: 
+1. **Access Token Required**:
+
    ```js
    // Before (v1.3.x)
    await TikTokBusiness.initializeSdk(appId, ttAppId, debug);
-   
+
    // After (v1.4.1)
    await TikTokBusiness.initializeSdk(appId, ttAppId, accessToken, debug);
    ```
 
 2. **Promise-based API**: All methods now return promises
+
    ```js
    // Before (v1.3.x)
    TikTokBusiness.trackEvent(TikTokEventName.LOGIN); // void
-   
+
    // After (v1.4.1)
    await TikTokBusiness.trackEvent(TikTokEventName.LOGIN); // Promise<string>
    ```
@@ -144,6 +157,7 @@ To upgrade from v1.3.x to v1.4.1:
 ## [1.3.x] - Previous Versions
 
 ### Features
+
 - Basic TikTok Business SDK integration
 - iOS and Android support
 - Standard event tracking
@@ -152,6 +166,7 @@ To upgrade from v1.3.x to v1.4.1:
 - User identification and logout
 
 ### Technical Details
+
 - TikTok Business SDK v1.3.x
 - Callback-based API
 - Basic error handling

--- a/README.md
+++ b/README.md
@@ -113,6 +113,39 @@ await TikTokBusiness.initializeSdk(
 );
 ```
 
+#### Disable Automatic Events
+
+You can disable TikTok SDK automatic events during initialization by passing an options object as the fourth argument:
+
+```js
+await TikTokBusiness.initializeSdk(
+  'YOUR_APP_ID',
+  'YOUR_TIKTOK_APP_ID',
+  'YOUR_ACCESS_TOKEN',
+  {
+    // Disable all automatic events
+    disableAutomaticTracking: true,
+  }
+);
+```
+
+Or disable only specific automatic event categories:
+
+```js
+await TikTokBusiness.initializeSdk(
+  'YOUR_APP_ID',
+  'YOUR_TIKTOK_APP_ID',
+  'YOUR_ACCESS_TOKEN',
+  {
+    debug: true,
+    disableInstallTracking: true,
+    disableLaunchTracking: true,
+    disableRetentionTracking: true,
+    disablePaymentTracking: true,
+  }
+);
+```
+
 **Important Validation Rules:**
 - App IDs must be numeric strings
 - No spaces allowed in comma-separated format
@@ -306,7 +339,7 @@ All methods return promises and support async/await pattern:
 
 ```typescript
 // Initialize SDK (required before any other calls)
-initializeSdk(appId: string, ttAppId: string | string[], accessToken: string, debug?: boolean): Promise<string>
+initializeSdk(appId: string, ttAppId: string | string[], accessToken: string, options?: boolean | TikTokInitializeOptions): Promise<string>
 
 // User management
 identify(externalId: string, externalUserName: string, phoneNumber: string, email: string): Promise<string>
@@ -337,6 +370,19 @@ interface AdRevenueData {
   country?: string;        // Country code where ad was shown
   precision?: string;      // Precision level of revenue data
   [key: string]: string | number | boolean | undefined; // Additional custom properties
+}
+```
+
+#### TikTokInitializeOptions Interface
+
+```typescript
+interface TikTokInitializeOptions {
+  debug?: boolean;
+  disableAutomaticTracking?: boolean;
+  disableInstallTracking?: boolean;
+  disableLaunchTracking?: boolean;
+  disableRetentionTracking?: boolean;
+  disablePaymentTracking?: boolean;
 }
 ```
 

--- a/TikTokBusiness.podspec
+++ b/TikTokBusiness.podspec
@@ -18,7 +18,7 @@ Pod::Spec.new do |s|
   s.source_files = "ios/**/*.{h,m,mm,swift}"
   
   s.dependency "React-Core"
-  s.dependency "TikTokBusinessSDK", "1.6.0"
+  s.dependency "TikTokBusinessSDK", "1.6.1"
 
   # Swift/Objective-C compatibility
   s.pod_target_xcconfig = {

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -85,7 +85,7 @@ def kotlin_version = getExtOrDefault("kotlinVersion")
 dependencies {
   implementation "com.facebook.react:react-android"
   implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
-  implementation 'com.github.tiktok:tiktok-business-android-sdk:1.6.0'
+  implementation 'com.github.tiktok:tiktok-business-android-sdk:1.6.1'
   implementation 'androidx.lifecycle:lifecycle-process:2.8.7'
   implementation 'androidx.lifecycle:lifecycle-common-java8:2.8.7'
   implementation 'com.android.billingclient:billing:7.1.1'

--- a/android/src/main/java/com/tiktokbusiness/TikTokBusinessModule.kt
+++ b/android/src/main/java/com/tiktokbusiness/TikTokBusinessModule.kt
@@ -253,13 +253,39 @@ class TikTokBusinessModule(reactContext: ReactApplicationContext) :
   }
 
   @ReactMethod
-  fun initializeSdk(appId: String, ttAppId: String, accessToken: String, debug: Boolean?, promise: Promise) {
+  fun initializeSdk(
+    appId: String,
+    ttAppId: String,
+    accessToken: String,
+    options: ReadableMap?,
+    promise: Promise
+  ) {
     try {
       val configBuilder =
         TikTokBusinessSdk.TTConfig(reactApplicationContext, accessToken).setAppId(appId).setTTAppId(ttAppId)
 
-      if (debug == true) {
+      if (getBooleanOption(options, "debug")) {
         configBuilder.openDebugMode().setLogLevel(TikTokBusinessSdk.LogLevel.DEBUG)
+      }
+
+      if (getBooleanOption(options, "disableAutomaticTracking")) {
+        configBuilder.disableAutoEvents()
+      }
+
+      if (getBooleanOption(options, "disableInstallTracking")) {
+        configBuilder.disableInstallLogging()
+      }
+
+      if (getBooleanOption(options, "disableLaunchTracking")) {
+        configBuilder.disableLaunchLogging()
+      }
+
+      if (getBooleanOption(options, "disableRetentionTracking")) {
+        configBuilder.disableRetentionLogging()
+      }
+
+      if (getBooleanOption(options, "disablePaymentTracking")) {
+        configBuilder.disableAutoIapTrack()
       }
 
       TikTokBusinessSdk.initializeSdk(configBuilder, object : TikTokBusinessSdk.TTInitCallback {
@@ -275,6 +301,12 @@ class TikTokBusinessModule(reactContext: ReactApplicationContext) :
     } catch (e: Exception) {
       promise.reject("INIT_ERROR", "Failed to initialize TikTok SDK", e)
     }
+  }
+
+  private fun getBooleanOption(options: ReadableMap?, key: String): Boolean {
+    return options?.hasKey(key) == true &&
+      options.getType(key) == ReadableType.Boolean &&
+      options.getBoolean(key)
   }
 
   companion object {

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1526,7 +1526,7 @@ PODS:
     - React-perflogger (= 0.78.0)
     - React-utils (= 0.78.0)
   - SocketRocket (0.7.1)
-  - TikTokBusiness (1.6.0):
+  - TikTokBusiness (1.6.1):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -1546,9 +1546,9 @@ PODS:
     - ReactCodegen
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
-    - TikTokBusinessSDK (= 1.6.0)
+    - TikTokBusinessSDK (= 1.6.1)
     - Yoga
-  - TikTokBusinessSDK (1.6.0)
+  - TikTokBusinessSDK (1.6.1)
   - Yoga (0.0.0)
 
 DEPENDENCIES:
@@ -1773,67 +1773,67 @@ SPEC CHECKSUMS:
   fmt: a40bb5bd0294ea969aaaba240a927bd33d878cdd
   glog: eb93e2f488219332457c3c4eafd2738ddc7e80b8
   hermes-engine: b417d2b2aee3b89b58e63e23a51e02be91dc876d
-  RCT-Folly: e78785aa9ba2ed998ea4151e314036f6c49e6d82
+  RCT-Folly: 36fe2295e44b10d831836cc0d1daec5f8abcf809
   RCTDeprecation: b2eecf2d60216df56bc5e6be5f063826d3c1ee35
   RCTRequired: 78522de7dc73b81f3ed7890d145fa341f5bb32ea
   RCTTypeSafety: c135dd2bf50402d87fd12884cbad5d5e64850edd
   React: b229c49ed5898dab46d60f61ed5a0bfa2ee2fadb
   React-callinvoker: 2ac508e92c8bd9cf834cc7d7787d94352e4af58f
-  React-Core: 325b4f6d9162ae8b9a6ff42fe78e260eb124180d
-  React-CoreModules: 558041e5258f70cd1092f82778d07b8b2ff01897
-  React-cxxreact: 8fff17cbe76e6a8f9991b59552e1235429f9c74b
+  React-Core: 13cdd1558d0b3f6d9d5a22e14d89150280e79f02
+  React-CoreModules: b07a6744f48305405e67c845ebf481b6551b712a
+  React-cxxreact: 1055a86c66ac35b4e80bd5fb766aed5f494dfff4
   React-debug: 0a5fcdbacc6becba0521e910c1bcfdb20f32a3f6
-  React-defaultsnativemodule: 618dc50a0fad41b489997c3eb7aba3a74479fd14
-  React-domnativemodule: 7ba599afb6c2a7ec3eb6450153e2efe0b8747e9a
-  React-Fabric: 252112089d2c63308f4cbfade4010b6606db67d1
-  React-FabricComponents: 3c0f75321680d14d124438ab279c64ec2a3d13c4
-  React-FabricImage: 728b8061cdec2857ca885fd605ee03ad43ffca98
+  React-defaultsnativemodule: 4bb28fc97fee5be63a9ebf8f7a435cfe8ba69459
+  React-domnativemodule: b36a11c2597243d7563985028c51ece988d8ae33
+  React-Fabric: afc561718f25b2cd800b709d934101afe376a12c
+  React-FabricComponents: f4e0a4e18a27bf6d39cbf2a0b42f37a92fa4e37f
+  React-FabricImage: 37d8e8b672eda68a19d71143eb65148084efb325
   React-featureflags: 19682e02ef5861d96b992af16a19109c3dfc1200
-  React-featureflagsnativemodule: 23528c7e7d50782b7ef0804168ba40bbaf1e86ab
-  React-graphics: fefe48f71bfe6f48fd037f59e8277b12e91b6be1
-  React-hermes: a9a0c8377627b5506ef9a7b6f60a805c306e3f51
-  React-idlecallbacksnativemodule: 7e2b6a3b70e042f89cd91dbd73c479bb39a72a7e
-  React-ImageManager: e3300996ac2e2914bf821f71e2f2c92ae6e62ae2
-  React-jserrorhandler: fa75876c662e5d7e79d6efc763fc9f4c88e26986
-  React-jsi: f3f51595cc4c089037b536368f016d4742bf9cf7
-  React-jsiexecutor: cca6c232db461e2fd213a11e9364cfa6fdaa20eb
-  React-jsinspector: 2bd4c9fddf189d6ec2abf4948461060502582bef
-  React-jsinspectortracing: a417d8a0ad481edaa415734b4dac81e3e5ee7dc6
-  React-jsitracing: 1ff7172c5b0522cbf6c98d82bdbb160e49b5804e
-  React-logger: 018826bfd51b9f18e87f67db1590bc510ad20664
-  React-Mapbuffer: 3c11cee7737609275c7b66bd0b1de475f094cedf
-  React-microtasksnativemodule: 843f352b32aacbe13a9c750190d34df44c3e6c2c
-  React-NativeModulesApple: 88433b6946778bea9c153e27b671de15411bf225
-  React-perflogger: 9e8d3c0dc0194eb932162812a168aa5dc662f418
-  React-performancetimeline: 5a2d6efef52bdcefac079c7baa30934978acd023
+  React-featureflagsnativemodule: d7cddf6d907b4e5ab84f9e744b7e88461656e48c
+  React-graphics: b0f78580cdaf5800d25437e3d41cc6c3d83b7aea
+  React-hermes: 71186f872c932e4574d5feb3ed754dda63a0b3bd
+  React-idlecallbacksnativemodule: dd2af19cdd3bc55149d17a2409ed72b694dfbe9c
+  React-ImageManager: a77dde8d5aa6a2b6962c702bf3a47695ef0aa32b
+  React-jserrorhandler: 9c14e89f12d5904257a79aaf84a70cd2e5ac07ba
+  React-jsi: 0775a66820496769ad83e629f0f5cce621a57fc7
+  React-jsiexecutor: 2cf5ba481386803f3c88b85c63fa102cba5d769e
+  React-jsinspector: 8052d532bb7a98b6e021755674659802fb140cc5
+  React-jsinspectortracing: bdd8fd0adcb4813663562e7874c5842449df6d8a
+  React-jsitracing: 2bab3bf55de3d04baf205def375fa6643c47c794
+  React-logger: 795cd5055782db394f187f9db0477d4b25b44291
+  React-Mapbuffer: 0502faf46cab8fb89cfc7bf3e6c6109b6ef9b5de
+  React-microtasksnativemodule: 663bc64e3a96c5fc91081923ae7481adc1359a78
+  React-NativeModulesApple: 16fbd5b040ff6c492dacc361d49e63cba7a6a7a1
+  React-perflogger: ab51b7592532a0ea45bf6eed7e6cae14a368b678
+  React-performancetimeline: bc2e48198ec814d578ac8401f65d78a574358203
   React-RCTActionSheet: 592674cf61142497e0e820688f5a696e41bf16dd
-  React-RCTAnimation: e6d669872f9b3b4ab9527aab283b7c49283236b7
-  React-RCTAppDelegate: de2343fe08be4c945d57e0ecce44afcc7dd8fc03
-  React-RCTBlob: 3e2dce94c56218becc4b32b627fc2293149f798d
-  React-RCTFabric: cac2c033381d79a5956e08550b0220cb2d78ea93
-  React-RCTFBReactNativeSpec: d10ca5e0ccbfeac8c047361fedf8e4ac653887b6
-  React-RCTImage: dc04b176c022d12a8f55ae7a7279b1e091066ae0
-  React-RCTLinking: 88f5e37fe4f26fbc80791aa2a5f01baf9b9a3fd5
-  React-RCTNetwork: f213693565efbd698b8e9c18d700a514b49c0c8e
-  React-RCTSettings: a2d32a90c45a3575568cad850abc45924999b8a5
-  React-RCTText: 54cdcd1cbf6f6a91dc6317f5d2c2b7fc3f6bf7a0
-  React-RCTVibration: 11dae0e7f577b5807bb7d31e2e881eb46f854fd4
+  React-RCTAnimation: 8fbb8dba757b49c78f4db403133ab6399a4ce952
+  React-RCTAppDelegate: 7f88baa8cb4e5d6c38bb4d84339925c70c9ac864
+  React-RCTBlob: f89b162d0fe6b570a18e755eb16cbe356d3c6d17
+  React-RCTFabric: 8ad6d875abe6e87312cef90e4b15ef7f6bed72e6
+  React-RCTFBReactNativeSpec: 8c29630c2f379c729300e4c1e540f3d1b78d1936
+  React-RCTImage: ccac9969940f170503857733f9a5f63578e106e1
+  React-RCTLinking: d82427bbf18415a3732105383dff119131cadd90
+  React-RCTNetwork: 12ad4d0fbde939e00251ca5ca890da2e6825cc3c
+  React-RCTSettings: e7865bf9f455abf427da349c855f8644b5c39afa
+  React-RCTText: 2cdfd88745059ec3202a0842ea75a956c7d6f27d
+  React-RCTVibration: a3a1458e6230dfd64b3768ebc0a4aac430d9d508
   React-rendererconsistency: 64e897e00d2568fd8dfe31e2496f80e85c0aaad1
-  React-rendererdebug: 41ce452460c44bba715d9e41d5493a96de277764
+  React-rendererdebug: a3f6d3ae7d2fa0035885026756281c07ee32479e
   React-rncore: 58748c2aa445f56b99e5118dad0aedb51c40ce9f
-  React-RuntimeApple: 7785ed0d8ae54da65a88736bb63ca97608a6d933
-  React-RuntimeCore: 6029ea70bc77f98cfd43ebe69217f14e93ba1f12
+  React-RuntimeApple: f0fda7bacabd32daa099cfda8f07466c30acd149
+  React-RuntimeCore: 683ee0b6a76d4b4bf6fbf83a541895b4887cc636
   React-runtimeexecutor: a188df372373baf5066e6e229177836488799f80
-  React-RuntimeHermes: a264609c28b796edfffc8ae4cb8fad1773ab948b
-  React-runtimescheduler: 23ec3a1e0fb1ec752d1a9c1fb15258c30bfc7222
+  React-RuntimeHermes: 907c8e9bec13ea6466b94828c088c24590d4d0b6
+  React-runtimescheduler: a2e2a39125dd6426b5d8b773f689d660cd7c5f60
   React-timing: bb220a53a795ed57976a4855c521f3de2f298fe5
-  React-utils: 3b054aaebe658fc710a8d239d0e4b9fd3e0b78f9
-  ReactAppDependencyProvider: a1fb08dfdc7ebc387b2e54cfc9decd283ed821d8
-  ReactCodegen: 008c319179d681a6a00966edfc67fda68f9fbb2e
-  ReactCommon: 0c097b53f03d6bf166edbcd0915da32f3015dd90
+  React-utils: 300d8bbb6555dcffaca71e7a0663201b5c7edbbc
+  ReactAppDependencyProvider: f2e81d80afd71a8058589e19d8a134243fa53f17
+  ReactCodegen: a63a0ab6ae824aef2e8c744981edd718b16eb9f2
+  ReactCommon: 3d39389f8e2a2157d5c999f8fba57bd1c8f226f0
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748
-  TikTokBusiness: c7e318dc83b2f4e36e9e543fafe72141412856d8
-  TikTokBusinessSDK: 6fe49b5b06a24cfe6bf42da789e2f3c6ba39c0e3
+  TikTokBusiness: ac6bb85751201754168395e7c35f3182e42132aa
+  TikTokBusinessSDK: 349bb1dea1f90d01f9b39418ebe7c8eb981c04af
   Yoga: afd04ff05ebe0121a00c468a8a3c8080221cb14c
 
 PODFILE CHECKSUM: 7a7c0c6f752fa948630fa1e76dc25a74148d9e8f

--- a/ios/TikTokBusinessModule.mm
+++ b/ios/TikTokBusinessModule.mm
@@ -39,7 +39,7 @@ RCT_EXTERN_METHOD(trackAdRevenueEvent:(NSDictionary *)adRevenueJson
 RCT_EXTERN_METHOD(initializeSdk:(NSString *)appId
                   ttAppId:(NSString *)ttAppId
                   accessToken:(NSString *)accessToken
-                  debug:(nonnull NSNumber *)debug
+                  options:(NSDictionary *)options
                   resolver:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject)
 

--- a/ios/TikTokBusinessModule.swift
+++ b/ios/TikTokBusinessModule.swift
@@ -222,19 +222,38 @@ class TikTokBusinessModule: NSObject, RCTBridgeModule {
   }
   
   /// Initializes the TikTok SDK.
-  /// Accepts appId, ttAppId, accessToken, and an optional debug flag.
-  @objc func initializeSdk(_ appId: String, 
-                          ttAppId: String, 
-                          accessToken: String, 
-                          debug: NSNumber, 
+  /// Accepts appId, ttAppId, accessToken, and initialization options.
+  @objc func initializeSdk(_ appId: String,
+                          ttAppId: String,
+                          accessToken: String,
+                          options: NSDictionary,
                           resolver: @escaping RCTPromiseResolveBlock,
                           rejecter: @escaping RCTPromiseRejectBlock) {
     let config = TikTokConfig(accessToken: accessToken, appId: appId, tiktokAppId: ttAppId)
     
-    let debugValue = debug.boolValue
-    if debugValue {
+    if options["debug"] as? Bool == true {
       config?.enableDebugMode()
       config?.setLogLevel(TikTokLogLevelDebug)
+    }
+
+    if options["disableAutomaticTracking"] as? Bool == true {
+      config?.disableAutomaticTracking()
+    }
+
+    if options["disableInstallTracking"] as? Bool == true {
+      config?.disableInstallTracking()
+    }
+
+    if options["disableLaunchTracking"] as? Bool == true {
+      config?.disableLaunchTracking()
+    }
+
+    if options["disableRetentionTracking"] as? Bool == true {
+      config?.disableRetentionTracking()
+    }
+
+    if options["disablePaymentTracking"] as? Bool == true {
+      config?.disablePaymentTracking()
     }
     
     TikTokBusiness.initializeSdk(config) { success, error in

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-tiktok-business-sdk",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "description": "A React Native bridge for the TikTok Business SDK",
   "source": "./src/index.tsx",
   "main": "./lib/commonjs/index.js",

--- a/src/__tests__/edge-cases.test.tsx
+++ b/src/__tests__/edge-cases.test.tsx
@@ -17,6 +17,15 @@ const mockTikTokBusinessModule =
     typeof NativeModules.TikTokBusinessModule
   >;
 
+const defaultInitOptions = {
+  debug: false,
+  disableAutomaticTracking: false,
+  disableInstallTracking: false,
+  disableLaunchTracking: false,
+  disableRetentionTracking: false,
+  disablePaymentTracking: false,
+};
+
 describe('Edge Cases and Error Handling', () => {
   beforeEach(() => {
     jest.clearAllMocks();
@@ -51,7 +60,7 @@ describe('Edge Cases and Error Handling', () => {
         longAppId,
         longTtAppId,
         accessToken,
-        false
+        defaultInitOptions
       );
     });
   });

--- a/src/__tests__/index.test.tsx
+++ b/src/__tests__/index.test.tsx
@@ -22,6 +22,15 @@ const mockTikTokBusinessModule =
     typeof NativeModules.TikTokBusinessModule
   >;
 
+const defaultInitOptions = {
+  debug: false,
+  disableAutomaticTracking: false,
+  disableInstallTracking: false,
+  disableLaunchTracking: false,
+  disableRetentionTracking: false,
+  disablePaymentTracking: false,
+};
+
 describe('TikTokBusiness', () => {
   beforeEach(() => {
     jest.clearAllMocks();
@@ -42,11 +51,14 @@ describe('TikTokBusiness', () => {
         appId,
         ttAppId,
         accessToken,
-        debug
+        {
+          ...defaultInitOptions,
+          debug,
+        }
       );
     });
 
-    it('should default debug to false when not provided', async () => {
+    it('should default initialization options when not provided', async () => {
       const appId = 'test-app-id';
       const ttAppId = '123456';
       const accessToken = 'test-token';
@@ -59,7 +71,47 @@ describe('TikTokBusiness', () => {
         appId,
         ttAppId,
         accessToken,
-        false
+        defaultInitOptions
+      );
+    });
+
+    it('should accept initialization options for automatic tracking controls', async () => {
+      const options = {
+        debug: true,
+        disableAutomaticTracking: true,
+        disableInstallTracking: true,
+        disableLaunchTracking: true,
+        disableRetentionTracking: true,
+        disablePaymentTracking: true,
+      };
+
+      mockTikTokBusinessModule.initializeSdk.mockResolvedValue('success');
+
+      await initializeSdk('app-id', '123456', 'token', options);
+
+      expect(mockTikTokBusinessModule.initializeSdk).toHaveBeenCalledWith(
+        'app-id',
+        '123456',
+        'token',
+        options
+      );
+    });
+
+    it('should default omitted initialization option fields', async () => {
+      mockTikTokBusinessModule.initializeSdk.mockResolvedValue('success');
+
+      await initializeSdk('app-id', '123456', 'token', {
+        disableLaunchTracking: true,
+      });
+
+      expect(mockTikTokBusinessModule.initializeSdk).toHaveBeenCalledWith(
+        'app-id',
+        '123456',
+        'token',
+        {
+          ...defaultInitOptions,
+          disableLaunchTracking: true,
+        }
       );
     });
 
@@ -87,7 +139,7 @@ describe('TikTokBusiness', () => {
           'app-id',
           '123456',
           'token',
-          false
+          defaultInitOptions
         );
       });
 
@@ -100,7 +152,7 @@ describe('TikTokBusiness', () => {
           'app-id',
           '11,22,33',
           'token',
-          false
+          defaultInitOptions
         );
       });
 
@@ -113,7 +165,7 @@ describe('TikTokBusiness', () => {
           'app-id',
           '11,22,33',
           'token',
-          false
+          defaultInitOptions
         );
       });
 
@@ -126,7 +178,7 @@ describe('TikTokBusiness', () => {
           'app-id',
           '123456',
           'token',
-          false
+          defaultInitOptions
         );
       });
 
@@ -143,7 +195,7 @@ describe('TikTokBusiness', () => {
           'app-id',
           '1,2,3,4,5,6,7,8,9,10',
           'token',
-          false
+          defaultInitOptions
         );
       });
     });

--- a/src/__tests__/integration.test.tsx
+++ b/src/__tests__/integration.test.tsx
@@ -13,6 +13,15 @@ const mockTikTokBusinessModule =
     typeof NativeModules.TikTokBusinessModule
   >;
 
+const defaultInitOptions = {
+  debug: false,
+  disableAutomaticTracking: false,
+  disableInstallTracking: false,
+  disableLaunchTracking: false,
+  disableRetentionTracking: false,
+  disablePaymentTracking: false,
+};
+
 describe('Integration Tests', () => {
   beforeEach(() => {
     jest.clearAllMocks();
@@ -498,7 +507,10 @@ describe('Integration Tests', () => {
         'com.example.multiapp',
         '11,22,33',
         'test-token',
-        true
+        {
+          ...defaultInitOptions,
+          debug: true,
+        }
       );
 
       // 2. Track events after initialization
@@ -541,7 +553,7 @@ describe('Integration Tests', () => {
         'com.example.singleapp',
         '123456',
         'test-token',
-        false
+        defaultInitOptions
       );
     });
 
@@ -560,7 +572,35 @@ describe('Integration Tests', () => {
         'com.example.legacyapp',
         '11,22,33',
         'test-token',
-        true
+        {
+          ...defaultInitOptions,
+          debug: true,
+        }
+      );
+    });
+
+    it('should initialize SDK with automatic tracking controls', async () => {
+      mockTikTokBusinessModule.initializeSdk.mockResolvedValue('initialized');
+
+      await TikTokBusiness.initializeSdk(
+        'com.example.privacy',
+        '123456',
+        'token',
+        {
+          disableAutomaticTracking: true,
+          disablePaymentTracking: true,
+        }
+      );
+
+      expect(mockTikTokBusinessModule.initializeSdk).toHaveBeenCalledWith(
+        'com.example.privacy',
+        '123456',
+        'token',
+        {
+          ...defaultInitOptions,
+          disableAutomaticTracking: true,
+          disablePaymentTracking: true,
+        }
       );
     });
   });

--- a/src/__tests__/types.test.ts
+++ b/src/__tests__/types.test.ts
@@ -12,6 +12,7 @@ import {
   TikTokContentEventParameter,
   TikTokContentEventContentsParameter,
 } from '../index';
+import type { TikTokInitializeOptions } from '../index';
 
 // Get the mocked module
 const mockTikTokBusinessModule =
@@ -38,6 +39,24 @@ describe('TypeScript Type Validation', () => {
         initializeSdk('app-id', '123456', 'test-token');
         initializeSdk('app-id', '123456', 'test-token', true);
         initializeSdk('app-id', '123456', 'test-token', false);
+        initializeSdk('app-id', '123456', 'test-token', {
+          debug: true,
+          disableAutomaticTracking: true,
+          disableInstallTracking: true,
+          disableLaunchTracking: true,
+          disableRetentionTracking: true,
+          disablePaymentTracking: true,
+        });
+      }).not.toThrow();
+    });
+
+    it('should expose initialization options type', () => {
+      const options: TikTokInitializeOptions = {
+        disableLaunchTracking: true,
+      };
+
+      expect(() => {
+        initializeSdk('app-id', '123456', 'test-token', options);
       }).not.toThrow();
     });
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -98,6 +98,47 @@ type EventProps = {
   query: string;
 };
 
+export type TikTokInitializeOptions = {
+  /** Whether to enable debug mode */
+  debug?: boolean;
+  /** Disable all automatic TikTok SDK events */
+  disableAutomaticTracking?: boolean;
+  /** Disable automatic install event tracking */
+  disableInstallTracking?: boolean;
+  /** Disable automatic app launch event tracking */
+  disableLaunchTracking?: boolean;
+  /** Disable automatic retention event tracking */
+  disableRetentionTracking?: boolean;
+  /** Disable automatic payment event tracking */
+  disablePaymentTracking?: boolean;
+};
+
+type NormalizedTikTokInitializeOptions = Required<TikTokInitializeOptions>;
+
+function normalizeInitializeOptions(
+  options?: boolean | TikTokInitializeOptions
+): NormalizedTikTokInitializeOptions {
+  if (typeof options === 'boolean') {
+    return {
+      debug: options,
+      disableAutomaticTracking: false,
+      disableInstallTracking: false,
+      disableLaunchTracking: false,
+      disableRetentionTracking: false,
+      disablePaymentTracking: false,
+    };
+  }
+
+  return {
+    debug: options?.debug ?? false,
+    disableAutomaticTracking: options?.disableAutomaticTracking ?? false,
+    disableInstallTracking: options?.disableInstallTracking ?? false,
+    disableLaunchTracking: options?.disableLaunchTracking ?? false,
+    disableRetentionTracking: options?.disableRetentionTracking ?? false,
+    disablePaymentTracking: options?.disablePaymentTracking ?? false,
+  };
+}
+
 /**
  * Validates and normalizes TikTok App ID(s) to comma-separated string format.
  * @param ttAppId - Single TikTok App ID or array of App IDs
@@ -175,21 +216,22 @@ function validateAndNormalizeTikTokAppId(ttAppId: string | string[]): string {
  * @param appId - Your app ID: Android package name or iOS listing ID, eg: com.sample.app (from Play Store) or 9876543 (from App Store)
  * @param ttAppId - Your TikTok App ID (string) or App IDs (array). Array format: ['11', '22', '33']. Comma-separated string format: '11,22,33'
  * @param accessToken - Your access token from TikTok Events Manager
- * @param debug - Whether to enable debug mode
+ * @param options - Whether to enable debug mode, or initialization options
  * @returns A promise that resolves when the SDK is initialized.
  */
 export const initializeSdk = async (
   appId: string,
   ttAppId: string | string[],
   accessToken: string,
-  debug?: Boolean
+  options?: boolean | TikTokInitializeOptions
 ): Promise<string> => {
   const normalizedTtAppId = validateAndNormalizeTikTokAppId(ttAppId);
+  const normalizedOptions = normalizeInitializeOptions(options);
   return await TikTokBusinessModule.initializeSdk(
     appId,
     normalizedTtAppId,
     accessToken,
-    debug || false
+    normalizedOptions
   );
 };
 


### PR DESCRIPTION
## Summary

Cherry-pick upstream PR [mtebele#27](https://github.com/mtebele/react-native-tiktok-business-sdk/pull/27) to bump the native TikTok Business SDK from **1.6.0 → 1.6.1** on both iOS and Android, and add support for disabling auto logs at init time.

The previous pin was on an older SDK that included the "Multiple Purchase Events" bug; bumping fixes that issue.

- `chore: update native TikTok SDK to 1.6.1` — cherry-pick `1c388e3`
- `feat: add support to disable auto logs` — cherry-pick `20caf4f`
- `chore: bump Podfile.lock to TikTokBusinessSDK 1.6.1` — aligns `example/ios/Podfile.lock` with the new pod versions

Linear: [TECH-1821](https://linear.app/alvie/issue/TECH-1821/forker-mtebelereact-native-tiktok-business-sdk-et-bumper-les-sdk)

## Test plan

- [x] `yarn lint` passes
- [x] `yarn typecheck` passes
- [x] `yarn test` — 101/101 tests pass (including new `disableAutoLogs` tests)
- [x] Android build (`./gradlew assembleDebug`) — **BUILD SUCCESSFUL** with `tiktok-business-android-sdk:1.6.1`
- [x] iOS pods install — `TikTokBusiness 1.6.1` and `TikTokBusinessSDK 1.6.1` resolved correctly
- [ ] iOS `xcodebuild` of the example app — blocked locally by a pre-existing React Native 0.78 + Xcode 26 `fmt`/`consteval` toolchain incompatibility (unrelated to this SDK bump; CI runner with older Xcode should be fine)

🤖 Generated with [Claude Code](https://claude.com/claude-code)