### PR TITLE
feat: add Expo config plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,42 @@ npm install react-native-tiktok-business-sdk
 yarn add react-native-tiktok-business-sdk
 ```
 
+### Expo / Continuous Native Generation
+
+If your app uses Expo (managed or with Continuous Native Generation), add the bundled config plugin to `app.json` / `app.config.ts` to automate the required native edits at prebuild time:
+
+```json
+{
+  "expo": {
+    "plugins": [
+      [
+        "react-native-tiktok-business-sdk",
+        {
+          "ios": {
+            "tiktokAppId": "YOUR_IOS_TIKTOK_APP_ID",
+            "skAdNetworkIds": ["abc1234567.skadnetwork"],
+            "userTrackingPermission": "This identifier will be used to deliver personalized ads to you."
+          },
+          "android": {
+            "tiktokAppId": "YOUR_ANDROID_TIKTOK_APP_ID"
+          }
+        }
+      ]
+    ]
+  }
+}
+```
+
+The plugin automatically:
+
+- Appends `22mmun2rn5.skadnetwork` (TikTok's SKAdNetwork identifier) to `SKAdNetworkItems` in `Info.plist`
+- Appends `tiktok`, `snssdk1233` and `snssdk1180` to `LSApplicationQueriesSchemes` in `Info.plist`
+- Writes the `TikTokAppID` key in `Info.plist` when `ios.tiktokAppId` is provided
+- Writes `NSUserTrackingUsageDescription` when `ios.userTrackingPermission` is provided — omit it if `expo-tracking-transparency` already manages it for your app
+- Adds the `com.tiktok.sdk.AppId` `<meta-data>` entry to `AndroidManifest.xml` when `android.tiktokAppId` is provided
+
+All mods are idempotent: running `expo prebuild` multiple times will not duplicate entries. After updating the configuration, regenerate the native projects with `npx expo prebuild --clean`.
+
 ### iOS Setup
 
 1. Run pod install in your `ios` directory:

--- a/app.plugin.js
+++ b/app.plugin.js
@@ -1,0 +1,4 @@
+// Expo config plugin entry point for `react-native-tiktok-business-sdk`.
+// Must remain CommonJS so it loads correctly when Expo resolves the plugin
+// from `app.json` / `app.config.ts`, regardless of the consuming app's setup.
+module.exports = require('./plugin/build/withTikTokBusiness');

--- a/package.json
+++ b/package.json
@@ -23,6 +23,9 @@
     "android",
     "ios",
     "cpp",
+    "app.plugin.js",
+    "plugin/build",
+    "plugin/src",
     "*.podspec",
     "react-native.config.js",
     "!ios/build",
@@ -38,10 +41,11 @@
   ],
   "scripts": {
     "test": "jest",
-    "typecheck": "tsc",
+    "typecheck": "tsc && tsc --noEmit -p plugin/tsconfig.json",
     "lint": "eslint \"**/*.{js,ts,tsx}\"",
-    "clean": "del-cli android/build example/android/build example/android/app/build example/ios/build lib",
-    "prepare": "bob build",
+    "clean": "del-cli android/build example/android/build example/android/app/build example/ios/build lib plugin/build",
+    "build:plugin": "tsc -p plugin/tsconfig.json",
+    "prepare": "bob build && yarn build:plugin",
     "release": "dotenv release-it --"
   },
   "keywords": [
@@ -69,6 +73,7 @@
     "@commitlint/cli": "^19.7.1",
     "@commitlint/config-conventional": "^19.7.1",
     "@evilmartians/lefthook": "^1.5.0",
+    "@expo/config-plugins": "^9.0.0",
     "@react-native/eslint-config": "^0.73.1",
     "@release-it/conventional-changelog": "^9.0.2",
     "@types/jest": "^29.5.5",
@@ -92,8 +97,14 @@
     "conventional-changelog-conventionalcommits": "9.0.0"
   },
   "peerDependencies": {
+    "expo": ">=50.0.0",
     "react": "*",
     "react-native": "*"
+  },
+  "peerDependenciesMeta": {
+    "expo": {
+      "optional": true
+    }
   },
   "workspaces": [
     "example"
@@ -110,8 +121,11 @@
     ],
     "collectCoverageFrom": [
       "src/**/*.{ts,tsx}",
+      "plugin/src/**/*.ts",
       "!src/**/*.d.ts",
-      "!src/__tests__/**"
+      "!plugin/src/**/*.d.ts",
+      "!src/__tests__/**",
+      "!plugin/src/__tests__/**"
     ],
     "coverageReporters": [
       "text",
@@ -119,7 +133,8 @@
       "html"
     ],
     "testMatch": [
-      "<rootDir>/src/__tests__/**/*.test.{ts,tsx}"
+      "<rootDir>/src/__tests__/**/*.test.{ts,tsx}",
+      "<rootDir>/plugin/src/__tests__/**/*.test.ts"
     ]
   },
   "commitlint": {

--- a/plugin/src/__tests__/withTikTokBusiness.test.ts
+++ b/plugin/src/__tests__/withTikTokBusiness.test.ts
@@ -1,0 +1,252 @@
+import { AndroidConfig } from '@expo/config-plugins';
+import type { InfoPlist } from '@expo/config-plugins/build/ios/IosConfig.types';
+
+import withTikTokBusiness, {
+  addApplicationQueriesSchemes,
+  addSKAdNetworkItems,
+  applyTikTokAndroidManifest,
+  applyTikTokInfoPlist,
+  setTikTokAppId,
+  setUserTrackingPermission,
+} from '../withTikTokBusiness';
+
+const TIKTOK_SKADNETWORK_ID = '22mmun2rn5.skadnetwork';
+const TIKTOK_QUERY_SCHEMES = ['tiktok', 'snssdk1233', 'snssdk1180'];
+const ANDROID_META_DATA_APP_ID = 'com.tiktok.sdk.AppId';
+
+function buildBaseAndroidManifest(): AndroidConfig.Manifest.AndroidManifest {
+  return {
+    manifest: {
+      $: { 'xmlns:android': 'http://schemas.android.com/apk/res/android' },
+      application: [
+        {
+          $: { 'android:name': '.MainApplication' },
+        },
+      ],
+      queries: [],
+    },
+  };
+}
+
+function buildBaseExpoConfig() {
+  return {
+    name: 'TestApp',
+    slug: 'test-app',
+  };
+}
+
+describe('addSKAdNetworkItems', () => {
+  it('adds the TikTok SKAdNetwork identifier when the plist is empty', () => {
+    const result = addSKAdNetworkItems({}, [TIKTOK_SKADNETWORK_ID]);
+    expect(result.SKAdNetworkItems).toEqual([
+      { SKAdNetworkIdentifier: TIKTOK_SKADNETWORK_ID },
+    ]);
+  });
+
+  it('preserves existing SKAdNetwork identifiers from other plugins', () => {
+    const infoPlist: InfoPlist = {
+      SKAdNetworkItems: [{ SKAdNetworkIdentifier: 'v9wttpbfk9.skadnetwork' }],
+    };
+    const result = addSKAdNetworkItems(infoPlist, [TIKTOK_SKADNETWORK_ID]);
+    expect(result.SKAdNetworkItems).toEqual([
+      { SKAdNetworkIdentifier: 'v9wttpbfk9.skadnetwork' },
+      { SKAdNetworkIdentifier: TIKTOK_SKADNETWORK_ID },
+    ]);
+  });
+
+  it('is idempotent — re-runs do not duplicate identifiers', () => {
+    const first = addSKAdNetworkItems({}, [TIKTOK_SKADNETWORK_ID]);
+    const second = addSKAdNetworkItems(first, [TIKTOK_SKADNETWORK_ID]);
+    expect(second.SKAdNetworkItems).toEqual([
+      { SKAdNetworkIdentifier: TIKTOK_SKADNETWORK_ID },
+    ]);
+  });
+
+  it('normalizes identifiers to lowercase before deduping', () => {
+    const result = addSKAdNetworkItems({}, [
+      '22MMUN2RN5.skadnetwork',
+      '22mmun2rn5.skadnetwork',
+    ]);
+    expect(result.SKAdNetworkItems).toEqual([
+      { SKAdNetworkIdentifier: TIKTOK_SKADNETWORK_ID },
+    ]);
+  });
+});
+
+describe('addApplicationQueriesSchemes', () => {
+  it('adds TikTok schemes when none are configured', () => {
+    const result = addApplicationQueriesSchemes({}, TIKTOK_QUERY_SCHEMES);
+    expect(result.LSApplicationQueriesSchemes).toEqual(TIKTOK_QUERY_SCHEMES);
+  });
+
+  it('appends TikTok schemes after existing ones', () => {
+    const result = addApplicationQueriesSchemes(
+      { LSApplicationQueriesSchemes: ['fbapi'] },
+      TIKTOK_QUERY_SCHEMES
+    );
+    expect(result.LSApplicationQueriesSchemes).toEqual([
+      'fbapi',
+      ...TIKTOK_QUERY_SCHEMES,
+    ]);
+  });
+
+  it('is idempotent — re-runs do not duplicate schemes', () => {
+    const first = addApplicationQueriesSchemes({}, TIKTOK_QUERY_SCHEMES);
+    const second = addApplicationQueriesSchemes(first, TIKTOK_QUERY_SCHEMES);
+    expect(second.LSApplicationQueriesSchemes).toEqual(TIKTOK_QUERY_SCHEMES);
+  });
+});
+
+describe('setTikTokAppId', () => {
+  it('writes the TikTokAppID key when provided', () => {
+    const result = setTikTokAppId({}, '123456');
+    expect(result.TikTokAppID).toBe('123456');
+  });
+
+  it('leaves the plist untouched when no app id is provided', () => {
+    const result = setTikTokAppId({ TikTokAppID: 'existing' }, undefined);
+    expect(result.TikTokAppID).toBe('existing');
+  });
+
+  it('overrides an existing TikTokAppID when a new value is provided', () => {
+    const result = setTikTokAppId({ TikTokAppID: 'old' }, 'new');
+    expect(result.TikTokAppID).toBe('new');
+  });
+});
+
+describe('setUserTrackingPermission', () => {
+  it('writes NSUserTrackingUsageDescription when a description is provided', () => {
+    const result = setUserTrackingPermission({}, 'Track me');
+    expect(result.NSUserTrackingUsageDescription).toBe('Track me');
+  });
+
+  it('preserves any existing description when no value is provided', () => {
+    const result = setUserTrackingPermission(
+      { NSUserTrackingUsageDescription: 'pre-existing' },
+      undefined
+    );
+    expect(result.NSUserTrackingUsageDescription).toBe('pre-existing');
+  });
+});
+
+describe('applyTikTokInfoPlist', () => {
+  it('applies all defaults with empty options', () => {
+    const result = applyTikTokInfoPlist({}, {});
+    expect(result.SKAdNetworkItems).toEqual([
+      { SKAdNetworkIdentifier: TIKTOK_SKADNETWORK_ID },
+    ]);
+    expect(result.LSApplicationQueriesSchemes).toEqual(TIKTOK_QUERY_SCHEMES);
+    expect(result.TikTokAppID).toBeUndefined();
+    expect(result.NSUserTrackingUsageDescription).toBeUndefined();
+  });
+
+  it('appends additional skAdNetworkIds passed by the consumer', () => {
+    const result = applyTikTokInfoPlist(
+      {},
+      {
+        skAdNetworkIds: ['extra.skadnetwork'],
+      }
+    );
+    expect(result.SKAdNetworkItems).toEqual([
+      { SKAdNetworkIdentifier: TIKTOK_SKADNETWORK_ID },
+      { SKAdNetworkIdentifier: 'extra.skadnetwork' },
+    ]);
+  });
+
+  it('is fully idempotent across re-runs', () => {
+    const first = applyTikTokInfoPlist(
+      {},
+      {
+        tiktokAppId: '999',
+        userTrackingPermission: 'Track me',
+      }
+    );
+    const second = applyTikTokInfoPlist(first, {
+      tiktokAppId: '999',
+      userTrackingPermission: 'Track me',
+    });
+    expect(second.SKAdNetworkItems).toEqual([
+      { SKAdNetworkIdentifier: TIKTOK_SKADNETWORK_ID },
+    ]);
+    expect(second.LSApplicationQueriesSchemes).toEqual(TIKTOK_QUERY_SCHEMES);
+    expect(second.TikTokAppID).toBe('999');
+    expect(second.NSUserTrackingUsageDescription).toBe('Track me');
+  });
+});
+
+describe('applyTikTokAndroidManifest', () => {
+  it('adds the TikTok app id meta-data when provided', () => {
+    const manifest = buildBaseAndroidManifest();
+    const result = applyTikTokAndroidManifest(manifest, { tiktokAppId: '999' });
+    const mainApp = result.manifest.application?.[0];
+    expect(mainApp?.['meta-data']).toEqual([
+      {
+        $: {
+          'android:name': ANDROID_META_DATA_APP_ID,
+          'android:value': '999',
+        },
+      },
+    ]);
+  });
+
+  it('leaves the manifest untouched when no app id is provided', () => {
+    const manifest = buildBaseAndroidManifest();
+    const result = applyTikTokAndroidManifest(manifest, {});
+    expect(result.manifest.application?.[0]?.['meta-data']).toBeUndefined();
+  });
+
+  it('is idempotent — re-runs do not duplicate the meta-data entry', () => {
+    const manifest = buildBaseAndroidManifest();
+    const first = applyTikTokAndroidManifest(manifest, { tiktokAppId: '999' });
+    const second = applyTikTokAndroidManifest(first, { tiktokAppId: '999' });
+    const metaData = second.manifest.application?.[0]?.['meta-data'] ?? [];
+    expect(metaData).toHaveLength(1);
+    expect(metaData[0]?.$?.['android:value']).toBe('999');
+  });
+
+  it('replaces the previous value when the app id changes', () => {
+    const manifest = buildBaseAndroidManifest();
+    const first = applyTikTokAndroidManifest(manifest, { tiktokAppId: '999' });
+    const second = applyTikTokAndroidManifest(first, { tiktokAppId: '1234' });
+    const metaData = second.manifest.application?.[0]?.['meta-data'] ?? [];
+    expect(metaData).toHaveLength(1);
+    expect(metaData[0]?.$?.['android:value']).toBe('1234');
+  });
+});
+
+describe('withTikTokBusiness (top-level plugin)', () => {
+  it('schedules info plist and android manifest mods on the config', () => {
+    const config = withTikTokBusiness(buildBaseExpoConfig(), {
+      ios: { tiktokAppId: '999' },
+      android: { tiktokAppId: '999' },
+    }) as {
+      mods?: {
+        ios?: { infoPlist?: unknown };
+        android?: { manifest?: unknown };
+      };
+    };
+    expect(config.mods?.ios?.infoPlist).toBeDefined();
+    expect(config.mods?.android?.manifest).toBeDefined();
+  });
+
+  it('runs only once even if applied multiple times', () => {
+    const first = withTikTokBusiness(buildBaseExpoConfig(), {
+      android: { tiktokAppId: '999' },
+    });
+    const second = withTikTokBusiness(first, {
+      android: { tiktokAppId: '999' },
+    });
+    // createRunOncePlugin records the plugin in _internal.pluginHistory; a
+    // second invocation must not append duplicate mods.
+    expect(
+      (second as { _internal?: { pluginHistory?: Record<string, unknown> } })
+        ._internal?.pluginHistory
+    ).toBeDefined();
+  });
+
+  it('accepts being called with no options', () => {
+    expect(() =>
+      withTikTokBusiness(buildBaseExpoConfig(), undefined)
+    ).not.toThrow();
+  });
+});

--- a/plugin/src/withTikTokBusiness.ts
+++ b/plugin/src/withTikTokBusiness.ts
@@ -1,0 +1,191 @@
+import {
+  AndroidConfig,
+  type ConfigPlugin,
+  createRunOncePlugin,
+  withAndroidManifest,
+  withInfoPlist,
+} from '@expo/config-plugins';
+import type { InfoPlist } from '@expo/config-plugins/build/ios/IosConfig.types';
+
+const pkg = require('react-native-tiktok-business-sdk/package.json');
+
+const TIKTOK_SKADNETWORK_ID = '22mmun2rn5.skadnetwork';
+const TIKTOK_QUERY_SCHEMES = ['tiktok', 'snssdk1233', 'snssdk1180'];
+const ANDROID_META_DATA_APP_ID = 'com.tiktok.sdk.AppId';
+
+const {
+  addMetaDataItemToMainApplication,
+  getMainApplicationOrThrow,
+  removeMetaDataItemFromMainApplication,
+} = AndroidConfig.Manifest;
+
+export type TikTokBusinessPluginProps = {
+  /**
+   * Optional iOS-specific configuration.
+   */
+  ios?: {
+    /**
+     * Extra SKAdNetwork identifiers to append to `Info.plist`. TikTok's
+     * default identifier (`22mmun2rn5.skadnetwork`) is always added.
+     */
+    skAdNetworkIds?: string[];
+    /**
+     * TikTok App ID to embed in `Info.plist` under the `TikTokAppID` key.
+     */
+    tiktokAppId?: string;
+    /**
+     * Sets `NSUserTrackingUsageDescription` in `Info.plist`. Leave undefined
+     * if another plugin (e.g. `expo-tracking-transparency`) already manages it.
+     */
+    userTrackingPermission?: string;
+  };
+  /**
+   * Optional Android-specific configuration.
+   */
+  android?: {
+    /**
+     * TikTok App ID to embed in `AndroidManifest.xml` as `com.tiktok.sdk.AppId`
+     * meta-data. Omit to leave the manifest untouched.
+     */
+    tiktokAppId?: string;
+  };
+};
+
+export function addSKAdNetworkItems(
+  infoPlist: InfoPlist,
+  identifiers: string[]
+): InfoPlist {
+  const existing = Array.isArray(infoPlist.SKAdNetworkItems)
+    ? infoPlist.SKAdNetworkItems
+    : [];
+  const seen = new Set(
+    existing
+      .map((item) => item?.SKAdNetworkIdentifier)
+      .filter((id): id is string => typeof id === 'string')
+  );
+  const additions: { SKAdNetworkIdentifier: string }[] = [];
+  for (const raw of identifiers) {
+    const id = raw.toLowerCase();
+    if (seen.has(id)) {
+      continue;
+    }
+    seen.add(id);
+    additions.push({ SKAdNetworkIdentifier: id });
+  }
+  if (additions.length === 0) {
+    return infoPlist;
+  }
+  return {
+    ...infoPlist,
+    SKAdNetworkItems: [...existing, ...additions],
+  };
+}
+
+export function addApplicationQueriesSchemes(
+  infoPlist: InfoPlist,
+  schemes: string[]
+): InfoPlist {
+  const existing = Array.isArray(infoPlist.LSApplicationQueriesSchemes)
+    ? [...infoPlist.LSApplicationQueriesSchemes]
+    : [];
+  const seen = new Set(existing);
+  for (const scheme of schemes) {
+    if (!seen.has(scheme)) {
+      seen.add(scheme);
+      existing.push(scheme);
+    }
+  }
+  return {
+    ...infoPlist,
+    LSApplicationQueriesSchemes: existing,
+  };
+}
+
+export function setTikTokAppId(
+  infoPlist: InfoPlist,
+  tiktokAppId: string | undefined
+): InfoPlist {
+  if (!tiktokAppId) {
+    return infoPlist;
+  }
+  return {
+    ...infoPlist,
+    TikTokAppID: tiktokAppId,
+  };
+}
+
+export function setUserTrackingPermission(
+  infoPlist: InfoPlist,
+  description: string | undefined
+): InfoPlist {
+  if (!description) {
+    return infoPlist;
+  }
+  return {
+    ...infoPlist,
+    NSUserTrackingUsageDescription: description,
+  };
+}
+
+export function applyTikTokInfoPlist(
+  infoPlist: InfoPlist,
+  ios: TikTokBusinessPluginProps['ios'] = {}
+): InfoPlist {
+  const extraIds = Array.isArray(ios.skAdNetworkIds) ? ios.skAdNetworkIds : [];
+  let next = addSKAdNetworkItems(infoPlist, [
+    TIKTOK_SKADNETWORK_ID,
+    ...extraIds,
+  ]);
+  next = addApplicationQueriesSchemes(next, TIKTOK_QUERY_SCHEMES);
+  next = setTikTokAppId(next, ios.tiktokAppId);
+  next = setUserTrackingPermission(next, ios.userTrackingPermission);
+  return next;
+}
+
+export function applyTikTokAndroidManifest(
+  androidManifest: AndroidConfig.Manifest.AndroidManifest,
+  android: TikTokBusinessPluginProps['android'] = {}
+): AndroidConfig.Manifest.AndroidManifest {
+  if (!android.tiktokAppId) {
+    return androidManifest;
+  }
+  const mainApplication = getMainApplicationOrThrow(androidManifest);
+  // Remove any pre-existing entry to avoid duplicates on re-runs.
+  removeMetaDataItemFromMainApplication(
+    mainApplication,
+    ANDROID_META_DATA_APP_ID
+  );
+  addMetaDataItemToMainApplication(
+    mainApplication,
+    ANDROID_META_DATA_APP_ID,
+    android.tiktokAppId
+  );
+  return androidManifest;
+}
+
+const withTikTokBusiness: ConfigPlugin<TikTokBusinessPluginProps | void> = (
+  config,
+  props
+) => {
+  const options = props ?? {};
+
+  let next = withInfoPlist(config, (modConfig) => {
+    modConfig.modResults = applyTikTokInfoPlist(
+      modConfig.modResults,
+      options.ios
+    );
+    return modConfig;
+  });
+
+  next = withAndroidManifest(next, (modConfig) => {
+    modConfig.modResults = applyTikTokAndroidManifest(
+      modConfig.modResults,
+      options.android
+    );
+    return modConfig;
+  });
+
+  return next;
+};
+
+export default createRunOncePlugin(withTikTokBusiness, pkg.name, pkg.version);

--- a/plugin/tsconfig.json
+++ b/plugin/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "compilerOptions": {
+    "declaration": true,
+    "declarationMap": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "isolatedModules": true,
+    "lib": ["ES2020"],
+    "module": "CommonJS",
+    "moduleResolution": "Node",
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "outDir": "build",
+    "resolveJsonModule": true,
+    "rootDir": "src",
+    "skipLibCheck": true,
+    "sourceMap": true,
+    "strict": true,
+    "target": "ES2020"
+  },
+  "include": ["./src"],
+  "exclude": ["**/__tests__/*", "**/*.test.ts"]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -26,6 +26,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/code-frame@npm:~7.10.4":
+  version: 7.10.4
+  resolution: "@babel/code-frame@npm:7.10.4"
+  dependencies:
+    "@babel/highlight": ^7.10.4
+  checksum: feb4543c8a509fe30f0f6e8d7aa84f82b41148b963b826cd330e34986f649a85cb63b2f13dd4effdf434ac555d16f14940b8ea5f4433297c2f5ff85486ded019
+  languageName: node
+  linkType: hard
+
 "@babel/compat-data@npm:^7.22.6, @babel/compat-data@npm:^7.26.5, @babel/compat-data@npm:^7.26.8":
   version: 7.26.8
   resolution: "@babel/compat-data@npm:7.26.8"
@@ -274,6 +283,18 @@ __metadata:
     "@babel/template": ^7.26.9
     "@babel/types": ^7.26.9
   checksum: 06363f8288a24c1cfda03eccd775ac22f79cba319b533cb0e5d0f2a04a33512881cc3f227a4c46324935504fb92999cc4758b69b5e7b3846107eadcb5ee0abca
+  languageName: node
+  linkType: hard
+
+"@babel/highlight@npm:^7.10.4":
+  version: 7.25.9
+  resolution: "@babel/highlight@npm:7.25.9"
+  dependencies:
+    "@babel/helper-validator-identifier": ^7.25.9
+    chalk: ^2.4.2
+    js-tokens: ^4.0.0
+    picocolors: ^1.0.0
+  checksum: a6e0ac0a1c4bef7401915ca3442ab2b7ae4adf360262ca96b91396bfb9578abb28c316abf5e34460b780696db833b550238d9256bdaca60fade4ba7a67645064
   languageName: node
   linkType: hard
 
@@ -1820,6 +1841,63 @@ __metadata:
     lefthook: bin/index.js
   checksum: b6c6742e99d7c0ce192b2f05fd615c8d498e6d1c0981acaa31c86b94fd0ef90d4ecdfe2d1e7f4f1f008fab7ee06d3fbd2c76a88851b48d96ace9a23de9c172dd
   conditions: (os=darwin | os=linux | os=win32) & (cpu=x64 | cpu=arm64 | cpu=ia32)
+  languageName: node
+  linkType: hard
+
+"@expo/config-plugins@npm:^9.0.0":
+  version: 9.1.7
+  resolution: "@expo/config-plugins@npm:9.1.7"
+  dependencies:
+    "@expo/config-types": ^53.0.0
+    "@expo/json-file": ~9.1.3
+    "@expo/plist": ^0.3.3
+    "@expo/sdk-runtime-versions": ^1.0.0
+    chalk: ^4.1.2
+    debug: ^4.3.5
+    getenv: ^1.0.0
+    glob: ^10.4.2
+    resolve-from: ^5.0.0
+    semver: ^7.5.4
+    slash: ^3.0.0
+    slugify: ^1.6.6
+    xcode: ^3.0.1
+    xml2js: 0.6.0
+  checksum: 8eba71d88100c1c0572307256900b10b8375d3fac2496d0486e7d9d66d8dc4a979e907a12e5dfb3a7811871bef4ba5cc906559ceb371517b7308bd909f17730a
+  languageName: node
+  linkType: hard
+
+"@expo/config-types@npm:^53.0.0":
+  version: 53.0.5
+  resolution: "@expo/config-types@npm:53.0.5"
+  checksum: 3f4db2d9590c18fb178f7395739ee2200512ad7c253655be0bad7f3f0d948df89c1c69c7e949f202faa98eecbd4bbae3edfcf9264f97f49d4f7087f85c68af5d
+  languageName: node
+  linkType: hard
+
+"@expo/json-file@npm:~9.1.3":
+  version: 9.1.5
+  resolution: "@expo/json-file@npm:9.1.5"
+  dependencies:
+    "@babel/code-frame": ~7.10.4
+    json5: ^2.2.3
+  checksum: beedf9077dcff476acd895219e391e18079d3c375e58bb4902a4147fffe9774e11d4d1607cfc3488f8e9daec2c30e4d7c17c46fb701035ad7aabacaaf6d465b4
+  languageName: node
+  linkType: hard
+
+"@expo/plist@npm:^0.3.3":
+  version: 0.3.5
+  resolution: "@expo/plist@npm:0.3.5"
+  dependencies:
+    "@xmldom/xmldom": ^0.8.8
+    base64-js: ^1.2.3
+    xmlbuilder: ^15.1.1
+  checksum: b78fda216c63ab553b24e75e87021be09155cd16e0fcf666846c1a5ea33defa2d7f631ea504788a8e2c5d67b5f59b35d6a46fa79a244d5890ee26870caffec22
+  languageName: node
+  linkType: hard
+
+"@expo/sdk-runtime-versions@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "@expo/sdk-runtime-versions@npm:1.0.0"
+  checksum: 0942d5a356f590e8dc795761456cc48b3e2d6a38ad2a02d6774efcdc5a70424e05623b4e3e5d2fec0cdc30f40dde05c14391c781607eed3971bf8676518bfd9d
   languageName: node
   linkType: hard
 
@@ -3873,6 +3951,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@xmldom/xmldom@npm:^0.8.8":
+  version: 0.8.13
+  resolution: "@xmldom/xmldom@npm:0.8.13"
+  checksum: b5568a3dee6306c4c6256c94f27d74f904d7cc923607f0dcaa37998e370361ce37a6e99aa55e8e725f07079e619a6f8b3a7de218e76b522ba2b1aca3ada5265c
+  languageName: node
+  linkType: hard
+
+"@xmldom/xmldom@npm:^0.9.10":
+  version: 0.9.10
+  resolution: "@xmldom/xmldom@npm:0.9.10"
+  checksum: 420f3ba52316163384ce626cda087d06b0eb5888d393b00bbc5f56489bbaccc8633e9b078942ee05facda93fbf813b209a5deb5044f89a6e04373305a0e573c0
+  languageName: node
+  linkType: hard
+
 "JSONStream@npm:^1.3.5":
   version: 1.3.5
   resolution: "JSONStream@npm:1.3.5"
@@ -4035,7 +4127,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ansi-styles@npm:^3.2.0":
+"ansi-styles@npm:^3.2.0, ansi-styles@npm:^3.2.1":
   version: 3.2.1
   resolution: "ansi-styles@npm:3.2.1"
   dependencies:
@@ -4458,7 +4550,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"base64-js@npm:^1.3.1, base64-js@npm:^1.5.1":
+"base64-js@npm:^1.2.3, base64-js@npm:^1.3.1, base64-js@npm:^1.5.1":
   version: 1.5.1
   resolution: "base64-js@npm:1.5.1"
   checksum: 669632eb3745404c2f822a18fc3a0122d2f9a7a13f7fb8b5823ee19d1d2ff9ee5b52c53367176ea4ad093c332fd5ab4bd0ebae5a8e27917a4105a4cfc86b1005
@@ -4479,6 +4571,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"big-integer@npm:1.6.x":
+  version: 1.6.52
+  resolution: "big-integer@npm:1.6.52"
+  checksum: 6e86885787a20fed96521958ae9086960e4e4b5e74d04f3ef7513d4d0ad631a9f3bde2730fc8aaa4b00419fc865f6ec573e5320234531ef37505da7da192c40b
+  languageName: node
+  linkType: hard
+
 "bl@npm:^4.1.0":
   version: 4.1.0
   resolution: "bl@npm:4.1.0"
@@ -4487,6 +4586,24 @@ __metadata:
     inherits: ^2.0.4
     readable-stream: ^3.4.0
   checksum: 9e8521fa7e83aa9427c6f8ccdcba6e8167ef30cc9a22df26effcc5ab682ef91d2cbc23a239f945d099289e4bbcfae7a192e9c28c84c6202e710a0dfec3722662
+  languageName: node
+  linkType: hard
+
+"bplist-creator@npm:0.1.1":
+  version: 0.1.1
+  resolution: "bplist-creator@npm:0.1.1"
+  dependencies:
+    stream-buffers: 2.2.x
+  checksum: b0d40d1d1623f1afdbb575cfc8075d742d2c4f0eb458574be809e3857752d1042a39553b3943d2d7f505dde92bcd43e1d7bdac61c9cd44475d696deb79f897ce
+  languageName: node
+  linkType: hard
+
+"bplist-parser@npm:0.3.2":
+  version: 0.3.2
+  resolution: "bplist-parser@npm:0.3.2"
+  dependencies:
+    big-integer: 1.6.x
+  checksum: fad0f6eb155a9b636b4096a1725ce972a0386490d7d38df7be11a3a5645372446b7c44aacbc6626d24d2c17d8b837765361520ebf2960aeffcaf56765811620e
   languageName: node
   linkType: hard
 
@@ -4713,6 +4830,17 @@ __metadata:
   version: 1.0.30001793
   resolution: "caniuse-lite@npm:1.0.30001793"
   checksum: 912398ddd1260a1524b7172c575a57361b081df8978cbbe4db57c46516b65edd0c645e9874c98628363b68d408f05f494494bcd2cf586580adc46c3d04e97951
+  languageName: node
+  linkType: hard
+
+"chalk@npm:^2.4.2":
+  version: 2.4.2
+  resolution: "chalk@npm:2.4.2"
+  dependencies:
+    ansi-styles: ^3.2.1
+    escape-string-regexp: ^1.0.5
+    supports-color: ^5.3.0
+  checksum: ec3661d38fe77f681200f878edbd9448821924e0f93a9cefc0e26a33b145f1027a2084bf19967160d11e1f03bfe4eaffcabf5493b89098b2782c3fe0b03d80c2
   languageName: node
   linkType: hard
 
@@ -5452,6 +5580,18 @@ __metadata:
     supports-color:
       optional: true
   checksum: fb42df878dd0e22816fc56e1fdca9da73caa85212fbe40c868b1295a6878f9101ae684f4eeef516c13acfc700f5ea07f1136954f43d4cd2d477a811144136479
+  languageName: node
+  linkType: hard
+
+"debug@npm:^4.3.5":
+  version: 4.4.3
+  resolution: "debug@npm:4.4.3"
+  dependencies:
+    ms: ^2.1.3
+  peerDependenciesMeta:
+    supports-color:
+      optional: true
+  checksum: 4805abd570e601acdca85b6aa3757186084a45cff9b2fa6eee1f3b173caa776b45f478b2a71a572d616d2010cea9211d0ac4a02a610e4c18ac4324bde3760834
   languageName: node
   linkType: hard
 
@@ -6921,6 +7061,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"getenv@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "getenv@npm:1.0.0"
+  checksum: 19ae5cad603a1cf1bcb8fa3bed48e00d062eb0572a4404c02334b67f3b3499f238383082b064bb42515e9e25c2b08aef1a3e3d2b6852347721aa8b174825bd56
+  languageName: node
+  linkType: hard
+
 "giget@npm:^2.0.0":
   version: 2.0.0
   resolution: "giget@npm:2.0.0"
@@ -7024,6 +7171,22 @@ __metadata:
   bin:
     glob: dist/esm/bin.mjs
   checksum: 0bc725de5e4862f9f387fd0f2b274baf16850dcd2714502ccf471ee401803997983e2c05590cb65f9675a3c6f2a58e7a53f9e365704108c6ad3cbf1d60934c4a
+  languageName: node
+  linkType: hard
+
+"glob@npm:^10.4.2":
+  version: 10.5.0
+  resolution: "glob@npm:10.5.0"
+  dependencies:
+    foreground-child: ^3.1.0
+    jackspeak: ^3.1.2
+    minimatch: ^9.0.4
+    minipass: ^7.1.2
+    package-json-from-dist: ^1.0.0
+    path-scurry: ^1.11.1
+  bin:
+    glob: dist/esm/bin.mjs
+  checksum: cda96c074878abca9657bd984d2396945cf0d64283f6feeb40d738fe2da642be0010ad5210a1646244a5fc3511b0cab5a374569b3de5a12b8a63d392f18c6043
   languageName: node
   linkType: hard
 
@@ -7178,6 +7341,13 @@ __metadata:
   version: 1.1.0
   resolution: "has-bigints@npm:1.1.0"
   checksum: 79730518ae02c77e4af6a1d1a0b6a2c3e1509785532771f9baf0241e83e36329542c3d7a0e723df8cbc85f74eff4f177828a2265a01ba576adbdc2d40d86538b
+  languageName: node
+  linkType: hard
+
+"has-flag@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "has-flag@npm:3.0.0"
+  checksum: 4a15638b454bf086c8148979aae044dd6e39d63904cd452d970374fa6a87623423da485dfb814e7be882e05c096a7ccf1ebd48e7e7501d0208d8384ff4dea73b
   languageName: node
   linkType: hard
 
@@ -10868,6 +11038,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"plist@npm:^3.0.5":
+  version: 3.1.1
+  resolution: "plist@npm:3.1.1"
+  dependencies:
+    "@xmldom/xmldom": ^0.9.10
+    base64-js: ^1.5.1
+    xmlbuilder: ^15.1.1
+  checksum: 775b2befb6df97b145193e5c241dc63929c58c89673eebc51e06b4b5b3403d15d921140278644ddf6f51a6936d46450d35903a84fc4cba071c46d9c33141817d
+  languageName: node
+  linkType: hard
+
 "possible-typed-array-names@npm:^1.0.0":
   version: 1.1.0
   resolution: "possible-typed-array-names@npm:1.1.0"
@@ -11170,6 +11351,7 @@ __metadata:
     "@commitlint/cli": ^19.7.1
     "@commitlint/config-conventional": ^19.7.1
     "@evilmartians/lefthook": ^1.5.0
+    "@expo/config-plugins": ^9.0.0
     "@react-native/eslint-config": ^0.73.1
     "@release-it/conventional-changelog": ^9.0.2
     "@types/jest": ^29.5.5
@@ -11188,8 +11370,12 @@ __metadata:
     turbo: ^1.10.7
     typescript: ^5.2.2
   peerDependencies:
+    expo: ">=50.0.0"
     react: "*"
     react-native: "*"
+  peerDependenciesMeta:
+    expo:
+      optional: true
   languageName: unknown
   linkType: soft
 
@@ -11857,6 +12043,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"sax@npm:>=0.6.0":
+  version: 1.6.0
+  resolution: "sax@npm:1.6.0"
+  checksum: 83ae2a17f524bd35b1b7d1c867700b1fab41e4cbb4f7635b7e66398421e06ff2cd43ec651c151cb99c67c3681ec7d0493cb6a98fd2e7799ea15b5d0a4615f870
+  languageName: node
+  linkType: hard
+
 "scheduler@npm:0.24.0-canary-efb381bbf-20230505":
   version: 0.24.0-canary-efb381bbf-20230505
   resolution: "scheduler@npm:0.24.0-canary-efb381bbf-20230505"
@@ -12113,6 +12306,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"simple-plist@npm:^1.1.0":
+  version: 1.4.0
+  resolution: "simple-plist@npm:1.4.0"
+  dependencies:
+    bplist-creator: 0.1.1
+    bplist-parser: 0.3.2
+    plist: ^3.0.5
+  checksum: fa8086f6b781c289f1abad21306481dda4af6373b32a5d998a70e53c2b7218a1d21ebb5ae3e736baae704c21d311d3d39d01d0e6a2387eda01b4020b9ebd909e
+  languageName: node
+  linkType: hard
+
 "sisteransi@npm:^1.0.5":
   version: 1.0.5
   resolution: "sisteransi@npm:1.0.5"
@@ -12142,6 +12346,13 @@ __metadata:
     astral-regex: ^1.0.0
     is-fullwidth-code-point: ^2.0.0
   checksum: 4e82995aa59cef7eb03ef232d73c2239a15efa0ace87a01f3012ebb942e963fbb05d448ce7391efcd52ab9c32724164aba2086f5143e0445c969221dde3b6b1e
+  languageName: node
+  linkType: hard
+
+"slugify@npm:^1.6.6":
+  version: 1.6.9
+  resolution: "slugify@npm:1.6.9"
+  checksum: ace83853caefa3a3284c9e66cc85175ec8420ba60fbab75b996c4077d6187a98443f59fffee170f5e0ed448d238fae4653f6afae29b046a1eb029359033e2fb6
   languageName: node
   linkType: hard
 
@@ -12314,6 +12525,13 @@ __metadata:
   version: 0.2.2
   resolution: "stdin-discarder@npm:0.2.2"
   checksum: 642ffd05bd5b100819d6b24a613d83c6e3857c6de74eb02fc51506fa61dc1b0034665163831873868157c4538d71e31762bcf319be86cea04c3aba5336470478
+  languageName: node
+  linkType: hard
+
+"stream-buffers@npm:2.2.x":
+  version: 2.2.0
+  resolution: "stream-buffers@npm:2.2.0"
+  checksum: 4587d9e8f050d689fb38b4295e73408401b16de8edecc12026c6f4ae92956705ecfd995ae3845d7fa3ebf19502d5754df9143d91447fd881d86e518f43882c1c
   languageName: node
   linkType: hard
 
@@ -12537,6 +12755,15 @@ __metadata:
   version: 9.2.1
   resolution: "sudo-prompt@npm:9.2.1"
   checksum: 50a29eec2f264f2b78d891452a64112d839a30bffbff4ec065dba4af691a35b23cdb8f9107d413e25c1a9f1925644a19994c00602495cab033d53f585fdfd665
+  languageName: node
+  linkType: hard
+
+"supports-color@npm:^5.3.0":
+  version: 5.5.0
+  resolution: "supports-color@npm:5.5.0"
+  dependencies:
+    has-flag: ^3.0.0
+  checksum: 95f6f4ba5afdf92f495b5a912d4abee8dcba766ae719b975c56c084f5004845f6f5a5f7769f52d53f40e21952a6d87411bafe34af4a01e65f9926002e38e1dac
   languageName: node
   linkType: hard
 
@@ -13140,6 +13367,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"uuid@npm:^7.0.3":
+  version: 7.0.3
+  resolution: "uuid@npm:7.0.3"
+  bin:
+    uuid: dist/bin/uuid
+  checksum: f5b7b5cc28accac68d5c083fd51cca64896639ebd4cca88c6cfb363801aaa83aa439c86dfc8446ea250a7a98d17afd2ad9e88d9d4958c79a412eccb93bae29de
+  languageName: node
+  linkType: hard
+
 "v8-to-istanbul@npm:^9.0.1":
   version: 9.3.0
   resolution: "v8-to-istanbul@npm:9.3.0"
@@ -13437,6 +13673,40 @@ __metadata:
   dependencies:
     is-wsl: ^3.1.0
   checksum: de4c92187e04c3c27b4478f410a02e81c351dc85efa3447bf1666f34fc80baacd890a6698ec91995631714086992036013286aea3d77e6974020d40a08e00aec
+  languageName: node
+  linkType: hard
+
+"xcode@npm:^3.0.1":
+  version: 3.0.1
+  resolution: "xcode@npm:3.0.1"
+  dependencies:
+    simple-plist: ^1.1.0
+    uuid: ^7.0.3
+  checksum: 908ff85851f81aec6e36ca24427db092e1cc068f052716e14de5e762196858039efabbe053a1abe8920184622501049e74a93618e8692b982f7604a9847db108
+  languageName: node
+  linkType: hard
+
+"xml2js@npm:0.6.0":
+  version: 0.6.0
+  resolution: "xml2js@npm:0.6.0"
+  dependencies:
+    sax: ">=0.6.0"
+    xmlbuilder: ~11.0.0
+  checksum: 437f353fd66d367bf158e9555a0625df9965d944e499728a5c6bc92a54a2763179b144f14b7e1c725040f56bbd22b0fa6cfcb09ec4faf39c45ce01efe631f40b
+  languageName: node
+  linkType: hard
+
+"xmlbuilder@npm:^15.1.1":
+  version: 15.1.1
+  resolution: "xmlbuilder@npm:15.1.1"
+  checksum: 14f7302402e28d1f32823583d121594a9dca36408d40320b33f598bd589ca5163a352d076489c9c64d2dc1da19a790926a07bf4191275330d4de2b0d85bb1843
+  languageName: node
+  linkType: hard
+
+"xmlbuilder@npm:~11.0.0":
+  version: 11.0.1
+  resolution: "xmlbuilder@npm:11.0.1"
+  checksum: 7152695e16f1a9976658215abab27e55d08b1b97bca901d58b048d2b6e106b5af31efccbdecf9b07af37c8377d8e7e821b494af10b3a68b0ff4ae60331b415b0
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

Adds an Expo config plugin to this SDK so that Expo CNG / managed apps can pick up the required native edits (`Info.plist`, `AndroidManifest.xml`) automatically at prebuild time, without ejecting or maintaining their own patches.

## What the plugin does

**iOS (`Info.plist`)**
- Appends TikTok's SKAdNetwork id `22mmun2rn5.skadnetwork` to `SKAdNetworkItems` (extra ids accepted via `ios.skAdNetworkIds`)
- Appends `tiktok`, `snssdk1233`, `snssdk1180` to `LSApplicationQueriesSchemes`
- Writes `TikTokAppID` when `ios.tiktokAppId` is provided
- Writes `NSUserTrackingUsageDescription` when `ios.userTrackingPermission` is provided (left untouched otherwise so plugins like `expo-tracking-transparency` can manage it)

**Android (`AndroidManifest.xml`)**
- Adds `<meta-data android:name="com.tiktok.sdk.AppId" android:value="..." />` when `android.tiktokAppId` is provided

All mods are **idempotent**: Set-based dedupe on iOS, remove-then-add on Android, and `createRunOncePlugin` as a safety net so re-running `expo prebuild` never duplicates entries.

## File layout

- `app.plugin.js` — CJS entry point (Expo loads this synchronously)
- `plugin/src/withTikTokBusiness.ts` — TypeScript plugin (exports pure helpers for testability)
- `plugin/src/__tests__/withTikTokBusiness.test.ts` — 22 unit tests
- `plugin/tsconfig.json` — isolated TS config that emits CJS into `plugin/build/`
- `package.json` — adds `build:plugin` script (run by `prepare`), publishes `app.plugin.js` + `plugin/build` + `plugin/src`, declares `@expo/config-plugins` as dev dep and `expo` as an **optional** peer dep
- `README.md` — new "Expo / Continuous Native Generation" section with an `app.json` example

## Example usage

```json
{
  "expo": {
    "plugins": [
      [
        "react-native-tiktok-business-sdk",
        {
          "ios": { "tiktokAppId": "YOUR_IOS_TIKTOK_APP_ID" },
          "android": { "tiktokAppId": "YOUR_ANDROID_TIKTOK_APP_ID" }
        }
      ]
    ]
  }
}
```

## Test plan

- [x] `yarn typecheck` — passes (SDK + plugin)
- [x] `yarn lint` — passes
- [x] `yarn test` — **122/122** (100 existing + 22 new plugin tests)
- [x] `yarn build:plugin` — produces `plugin/build/withTikTokBusiness.{js,d.ts}`
- [ ] Smoke test via `expo prebuild` in a consuming app

Refs TECH-1822.