### PR TITLE
feat: add disableSKAdNetworkSupport option to SDK config (iOS)

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,7 @@ const options: TikTokSdkConfig = {
   disableLaunchTracking: true,      // Don't report app launch event
   disableRetentionTracking: true,   // Don't report 2D-retention event
   disablePaymentTracking: true,     // Don't report automatic IAP event
+  disableSKAdNetworkSupport: true,  // iOS only: don't update SKAdNetwork conversion values
 };
 
 await TikTokBusiness.initializeSdk(

--- a/ios/TikTokBusinessModule.swift
+++ b/ios/TikTokBusinessModule.swift
@@ -263,6 +263,9 @@ class TikTokBusinessModule: NSObject, RCTBridgeModule {
       if opts["disablePaymentTracking"] as? Bool == true {
         config?.disablePaymentTracking()
       }
+      if opts["disableSKAdNetworkSupport"] as? Bool == true {
+        config?.disableSKAdNetworkSupport()
+      }
     }
 
     TikTokBusiness.initializeSdk(config) { success, error in

--- a/src/__tests__/index.test.tsx
+++ b/src/__tests__/index.test.tsx
@@ -106,6 +106,25 @@ describe('TikTokBusiness', () => {
       );
     });
 
+    it('should pass disableSKAdNetworkSupport option to native module', async () => {
+      const appId = 'test-app-id';
+      const ttAppId = '123456';
+      const accessToken = 'test-token';
+      const options = { disableSKAdNetworkSupport: true };
+
+      mockTikTokBusinessModule.initializeSdk.mockResolvedValue('success');
+
+      await initializeSdk(appId, ttAppId, accessToken, undefined, options);
+
+      expect(mockTikTokBusinessModule.initializeSdk).toHaveBeenCalledWith(
+        appId,
+        ttAppId,
+        accessToken,
+        false,
+        options
+      );
+    });
+
     it('should default options to empty object when not provided', async () => {
       mockTikTokBusinessModule.initializeSdk.mockResolvedValue('success');
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -176,6 +176,7 @@ export interface TikTokSdkConfig {
   disableLaunchTracking?: boolean;
   disableRetentionTracking?: boolean;
   disablePaymentTracking?: boolean;
+  disableSKAdNetworkSupport?: boolean;
 }
 
 /**


### PR DESCRIPTION
## Motivation

TikTok's official integration guidance states that apps using an MMP (AppsFlyer, Adjust, etc.) to update SKAdNetwork conversion values must disable the TikTok SDK's own SKAN support, to avoid the two SDKs overwriting each other's conversion values (the CV is a device-level single value — last writer wins, which corrupts iOS attribution across all channels).

The native iOS SDK already provides `disableSKAdNetworkSupport()` on `TikTokConfig`, but the bridge doesn't expose it, so RN apps with an MMP currently have no way to comply.

## Changes

- iOS: map a new `disableSKAdNetworkSupport` key in the options handling of `initializeSdk` → calls `config?.disableSKAdNetworkSupport()`
- TS: add the optional field to `TikTokSdkConfig`
- README: document the option alongside the existing disable flags
- Test: unit test mirroring the existing single-option test pattern

Android has no SKAdNetwork equivalent; the key is safely ignored there (options are read per known key).

## Usage

```ts
await TikTokBusiness.initializeSdk(appId, ttAppId, accessToken, false, {
  disableSKAdNetworkSupport: true, // iOS only
});
```

## Checks

- Full jest suite passes (101 tests, including the new one)
- No breaking changes — existing calls without the option are unaffected

We're running this change in production via patch-package and would love to drop the patch once it's upstream. Happy to adjust anything to fit the project's conventions.